### PR TITLE
Update version to match registry

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         version:
           - '1.1'
+          - '1.6'
+          - '1'
         os:
           - ubuntu-latest
           - windows-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CachedArrays"
 uuid = "d8fd01e4-1764-11e9-0a01-8f76bebf08d8"
-version = "0.1.0"
+version = "0.1.2"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
@@ -8,7 +8,9 @@ Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-julia = ">= 0.7"
+AxisArrays = "0.4"
+Images = "0.23, 0.24, 0.25"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Version 0.1.2 is in HolyLabRegistry, but the version number
was never updated here.

This also adds [compat] and widens CI coverage, but hopefully
this does not add any conflicts.